### PR TITLE
Require cabal-version 1.8

### DIFF
--- a/readable.cabal
+++ b/readable.cabal
@@ -11,7 +11,7 @@ license-file:   LICENSE
 author:         Doug Beardsley
 maintainer:     mightybyte@gmail.com
 build-type:     Simple
-cabal-version:  >= 1.6
+cabal-version:  >= 1.8
 homepage:       https://github.com/mightybyte/readable
 category:       Text
 


### PR DESCRIPTION
Hopefully this suppresses the following warning:
```
Warning: readable.cabal:31:27: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```