### PR TITLE
allow for newer bytestring

### DIFF
--- a/readable.cabal
+++ b/readable.cabal
@@ -23,7 +23,8 @@ tested-with:
   GHC==8.0.2,
   GHC==8.2.2,
   GHC==8.4.4,
-  GHC==8.6.3
+  GHC==8.6.3,
+  GHC==9.2.1
 
 extra-source-files:
   CHANGELOG.md
@@ -39,7 +40,7 @@ Library
 
   build-depends:
     base        >= 4    && < 5,
-    bytestring  >= 0.9  && < 0.11,
+    bytestring  >= 0.9  && < 0.12,
     text        >= 0.11 && < 1.3
 
   ghc-options: -Wall -fwarn-tabs


### PR DESCRIPTION
ghc9.2.1 has bytestring 0.11.1 so increase the bound