### PR TITLE
Bump build machinery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ cabal-dev
 *.chs.h
 *.swp
 .ghc.environment*
+/.stack-work
+/stack.yaml.lock

--- a/readable.cabal
+++ b/readable.cabal
@@ -1,5 +1,5 @@
 name:           readable
-version:        0.3.1
+version:        0.3.1.1
 synopsis:       Reading from Text and ByteString
 
 description:
@@ -11,7 +11,7 @@ license-file:   LICENSE
 author:         Doug Beardsley
 maintainer:     mightybyte@gmail.com
 build-type:     Simple
-cabal-version:  >= 1.6
+cabal-version:  >= 1.8
 homepage:       https://github.com/mightybyte/readable
 category:       Text
 
@@ -23,7 +23,8 @@ tested-with:
   GHC==8.0.2,
   GHC==8.2.2,
   GHC==8.4.4,
-  GHC==8.6.3
+  GHC==8.6.3,
+  GHC==9.2.4
 
 extra-source-files:
   CHANGELOG.md

--- a/readable.cabal
+++ b/readable.cabal
@@ -39,8 +39,8 @@ Library
 
   build-depends:
     base        >= 4    && < 5,
-    bytestring  >= 0.9  && < 0.11,
-    text        >= 0.11 && < 1.3
+    bytestring  >= 0.9  && < 0.12,
+    text        >= 0.11 && < 2.1
 
   ghc-options: -Wall -fwarn-tabs
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,4 @@
+resolver: nightly-2022-10-06
+packages: 
+- .
+extra-deps: []


### PR DESCRIPTION
Update the minimum `cabal-version:` entry _.cabal_ so it builds with current tooling.

Incorporate #3 and #4 to bump upper bounds on **text** and **bytestring**.

Add a _stack.yaml_ so people in that world can build, tested doing so with GHC 9.2.4.

This will allow us to get **readable** back into the Stackage nightly and in turn get **snap-core** back in.
 